### PR TITLE
Substituindo font-size fixo para unidade relativa (REM)

### DIFF
--- a/style.css
+++ b/style.css
@@ -7,6 +7,10 @@
     box-sizing: border-box;
 }
 
+button {
+    font: inherit;
+}
+
 body {
     margin-top: 8%;
     margin-bottom: 5%;
@@ -14,6 +18,7 @@ body {
     align-items: center;
     display: flex;
     flex-direction: column;
+    font-size: 15px;
 }
 
 img {
@@ -25,18 +30,15 @@ img {
 h1 {
     font-family: 'Big Shoulders Display', sans-serif;
     text-transform: uppercase;
-    font-size: 42px;
     margin-top: 30px;
     margin-left: 40px;
     margin-top: 40px;
     color: hsl(0, 0%, 95%);
-
+    font-size: 3rem;
 }
 
 p {
-    font-size: small;
     font-family: 'Lexend Deca', sans-serif;
-    font-size: 15px;
     line-height: 2;
     margin-top: 20px;
     margin-left: 40px;
@@ -58,7 +60,6 @@ button {
     text-align: center;
     padding: 10px;
     font-family: 'Lexend Deca', sans-serif;
-    font-size: 15px;
 }
 
 .colums {
@@ -146,7 +147,7 @@ button {
 }
 
 .attribution {
-    font-size: 11px;
+    font-size: 0.75rem;
     text-align: center;
 }
 
@@ -172,12 +173,7 @@ button {
   }  
   
   @media screen and (max-width: 480px) {
-    h1 {
-      font-size: 32px;
-    }
-  
     p {
-      font-size: 12px;
       line-height: 1.5;
       margin-left: 20px;
       margin-right: 20px;


### PR DESCRIPTION
No CSS, por padrão, os buttons não herdam o propriedades de fonte, por isso botei 
`button { font: inherit }`
Assim ele vai herdar todas as propriedades de fonte do body e não precisam botar a propriedade no botão.

É bom usar REM, é uma unidade de medida relativa a fonte, se a fonte padrão ( neste caso: o tamanho da fonte declarada no body} for 15px então 1rem será 15px, 2rem será 30px, 0.5rem será 7.5px e assim por diante.
Assim a gente só declara o valor fixo uma vez e vai aumentando ou diminuindo, na classe .attribute você queria uma fonte mais pequena então utilizei 0.75rem, 75% do tamanho da fonte padrão. 

Conteúdo sobre REM que recomendo: https://pingback.com/papodedev/css-rem-vs-em-vs-px-qual-usar

é interessante já começar a utilizar no início mesmo.

